### PR TITLE
Update FQDN filtering rules - add ubuntu port 80

### DIFF
--- a/app-fqdn-rules.tf
+++ b/app-fqdn-rules.tf
@@ -4,6 +4,7 @@ locals {
     tcp = {
       "*.aviatrix.com" = "443"
       "aviatrix.com"   = "80"
+      "*.ubuntu.com"   = "80"
     }
     udp = {
       "dns.google.com" = "53"

--- a/app-fqdn-rules.tf
+++ b/app-fqdn-rules.tf
@@ -4,7 +4,7 @@ locals {
     tcp = {
       "*.aviatrix.com" = "443"
       "aviatrix.com"   = "80"
-      "*.ubuntu.com"   = "80"
+      "*.ubuntu.com"   = "80"
     }
     udp = {
       "dns.google.com" = "53"


### PR DESCRIPTION
## Description

Add *.ubuntu to the egress FQDN filter.  this will allow the following commands to work;

sudo apt-get update -y
sudo apt-get upgrade -y